### PR TITLE
k8s intro exercise 

### DIFF
--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+    - image: negleb/otus-k8s-hw-2_hipster-frontend:hw_1.0.0
+      name: frontend
+      resources: {}
+      ports:
+        - containerPort: 8080
+      env:
+        - name: PORT
+          value: "8080"
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never
+status: {}

--- a/kubernetes-intro/frontend-pod.yaml
+++ b/kubernetes-intro/frontend-pod.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+  - image: negleb/otus-k8s-hw-2_hipster-frontend:hw_1.0.0
+    name: frontend
+    resources: {}
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never
+status: {}

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: web
+  labels:
+    key: app
+spec:
+  containers:
+    - name: web
+      image: negleb/otus-k8s-hw-2_web-app:2.0.0
+      volumeMounts:
+        - name: app
+          mountPath: /app
+  initContainers:
+    - name: init-index-page
+      image: busybox:1.31.0
+      command:
+        [
+          "sh",
+          "-c",
+          "wget -O- https://raw.githubusercontent.com/express42/otus-platform-snippets/master/Module-02/Introduction-to-Kubernetes/wget.sh | sh",
+        ]
+      volumeMounts:
+        - name: app
+          mountPath: /app
+  volumes:
+    - name: app
+      emptyDir: {}

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -11,6 +11,9 @@ spec:
       volumeMounts:
         - name: app
           mountPath: /app
+      env:
+        - name: SERVER_FOLDER
+          value: "/app"
   initContainers:
     - name: init-index-page
       image: busybox:1.31.0

--- a/kubernetes-intro/web/Dockerfile
+++ b/kubernetes-intro/web/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.7-alpine
+
+WORKDIR /usr/src/app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+USER 1001
+EXPOSE 8000
+
+CMD [ "python", "http-server.py" ]

--- a/kubernetes-intro/web/Dockerfile
+++ b/kubernetes-intro/web/Dockerfile
@@ -1,13 +1,13 @@
 FROM python:3.7-alpine
 
-WORKDIR /usr/src/app
-
-COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+WORKDIR /usr/src/web
 
 COPY . .
+RUN pip install --no-cache-dir -r requirements.txt &&\
+    chmod -R 777 /usr/src/web/
 
 USER 1001
 EXPOSE 8000
 
+ENV SERVER_FOLDER="/usr/src/web/app"
 CMD [ "python", "http-server.py" ]

--- a/kubernetes-intro/web/http-server.py
+++ b/kubernetes-intro/web/http-server.py
@@ -2,10 +2,22 @@
 import http.server
 import socketserver
 import os
+import sys
+import logging
 
 PORT = 8000
 DIRECTORY = os.environ['SERVER_FOLDER']
-print(DIRECTORY)
+
+
+def setupLogging(loglevel=logging.DEBUG):
+    logger = logging.getLogger()
+    logger.setLevel(loglevel)
+    ch = logging.StreamHandler(sys.stdout)
+    ch.setLevel(loglevel)
+    formatter = logging.Formatter("%(message)s")
+    ch.setFormatter(formatter)
+    logger.addHandler(ch)
+    return logger
 
 
 class Handler(http.server.SimpleHTTPRequestHandler):
@@ -13,6 +25,7 @@ class Handler(http.server.SimpleHTTPRequestHandler):
         super().__init__(*args, directory=DIRECTORY, **kwargs)
 
 
+logger = setupLogging("DEBUG")
 with socketserver.TCPServer(("", PORT), Handler) as httpd:
-    print("serving at port", PORT)
+    logger.debug("serving at port " + str(PORT))
     httpd.serve_forever()

--- a/kubernetes-intro/web/http-server.py
+++ b/kubernetes-intro/web/http-server.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+import http.server
+import socketserver
+import os
+
+PORT = 8000
+DIRECTORY = os.environ['SERVER_FOLDER']
+print(DIRECTORY)
+
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, directory=DIRECTORY, **kwargs)
+
+
+with socketserver.TCPServer(("", PORT), Handler) as httpd:
+    print("serving at port", PORT)
+    httpd.serve_forever()


### PR DESCRIPTION
# Выполнено ДЗ №

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
 - Задание 2.1 Вопрос. Ответ ниже в секции Questions from HM
 - Задание 2.2 Dockerfile. Описал web-server на python3 и описал для него Dockerfile
 - Задание 2.3 Манифест Pod. Описал под с web-server в web-pod.yaml
 - Задание 2.4 Hipster shop. Исправил frontend, который находился в статусе Error. Описание в чём конкретно была ошибка ниже в Questions from HM

## Как запустить проект:
### Задание 2.2 Dockerfile
- Выполнить команду
```
docker run --rm -it -p 8000:8000 negleb/otus-k8s-hw-2_web-app:2.0.0
```
- Перейти [http://localhost:8000/](http://localhost:8000/ )и проверить рабочие ссылки

### Задание 2.3 Манифест Pod
- Выполнить команду 
```
kubectl apply -f web-pod.yaml
kubectl port-forward --address 0.0.0.0 pod/web 8000:8000
```
- Открыть [http://localhost:8000/index.html](http://localhost:8000/index.html)
- Убедиться что появилась картинка с космическим кораблём Express42, а не танцующий парень с гифки

### Задание 2.4. Hipster shop

- Выполнить команду 
```
kubectl apply -f frontend-pod-healthy.yaml
kubectl describe pod frontend
```
- Убедиться что **Status:       Running**

## PR checklist:
 - [x] Выставлен label с темой домашнего задания

## Questions from HM
### 2.1 Вопрос
- Разберитесь почему все pod в namespace kube-system восстановились после удаления. Укажите причину в описании PR Hint: core-dns и, например, kube-apiserver, имеют различия в механизме запуска и восстанавливаются по разным причинам:

* core-dns описан в диплойменте, который можно увидеть ч/з
  kubectl describe deployments coredns

```
Replicas:               2 desired | 2 updated | 2 total | 2 available | 0 unavailable
```

kube-controller-manager -> Deployment controller контролирует жизненный цикл диплоймента, следит за тем, чтобы декларативное описание диплоймента соответствовало том, что сейчас задиплоено в k8s.

- kube-apiserver и другие системные описаны как [static pods](https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/). Их запуск контролирует kubelet, описание тут - > [Observe static pod behavior](https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/#behavior-of-static-pods)

```
minikube ssh
ps aux | grep pod-manifest
root      2456  3.4  4.6 1337324 91728 ?       Ssl  12:12   0:39 /var/lib/minikube/binaries/v1.17.0/kubelet --authorization-mode=Webhook --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --cgroup-driver=cgroupfs --client-ca-file=/var/lib/minikube/certs/ca.crt --cluster-dns=10.96.0.10 --cluster-domain=cluster.local --config=/var/lib/kubelet/config.yaml --container-runtime=docker --fail-swap-on=false --hostname-override=minikube --kubeconfig=/etc/kubernetes/kubelet.conf --node-ip=192.168.64.2 --pod-manifest-path=/etc/kubernetes/manifests
```

--pod-manifest-path=/etc/kubernetes/manifests - путь где лежат манифесты статик подов

```
$ ls -lht /etc/kubernetes/manifests/
total 20K
-rw------- 1 root root 1.8K Dec 15 12:12 etcd.yaml
-rw------- 1 root root 1.1K Dec 15 12:12 kube-scheduler.yaml
-rw------- 1 root root 2.5K Dec 15 12:12 kube-controller-manager.yaml
-rw------- 1 root root 2.9K Dec 15 12:12 kube-apiserver.yaml
-rw-r----- 1 root root 1.5K Jan  1  0001 addon-manager.yaml.tmpl
```
### 2.4 Hipster shop
frontend валится с ошибкой

```
kubectl get pods
NAME       READY   STATUS    RESTARTS   AGE
frontend   0/1     Error     0          11s
web        1/1     Running   1          21m
```

смотрим логи
kubectl -n default logs -f frontend
и находим, что не выставлена необходимая переменная

```
panic: environment variable "PRODUCT_CATALOG_SERVICE_ADDR" not set

goroutine 1 [running]:
main.mustMapEnv(0xc0000340b0, 0xb03c4a, 0x1c)
	/go/src/github.com/GoogleCloudPlatform/microservices-demo/src/frontend/main.go:248 +0x10e
main.main()
	/go/src/github.com/GoogleCloudPlatform/microservices-demo/src/frontend/main.go:106 +0x3e9
```

Помог поиск по репозиторию, где значение этой и других переменных можно найти в манифесте от гугла [frontend.yaml](https://github.com/GoogleCloudPlatform/microservices-demo/blob/master/kubernetes-manifests/frontend.yaml)

Добавляем значения переменных и создаем новый под